### PR TITLE
Add "-Olevel 3" to options of find

### DIFF
--- a/plugin/quick_file.vim
+++ b/plugin/quick_file.vim
@@ -29,7 +29,7 @@ def find(sp,pwd, args, timeout):
     if _platform.find('linux') == 0 or _platform == 'darwin':
         name = '*%s*'%(args[0])
         others = args[1:]
-        inputs = 'find %s -type f -name "%s" '%(sp,name)
+        inputs = 'find %s -Olevel 3 -type f -name "%s" '%(sp,name)
         for ignore in ['*.pyc','*.swp','*.class']:
             inputs += '-and -not -name "%s"'%(ignore)
         for other in others:


### PR DESCRIPTION
> -Olevel
              Enables  query  optimisation.    The  find program reorders tests to speed up execution while preserving the overall effect; that is, predicates with side
              effects are not reordered relative to each other.  The optimisations performed at each optimisation level are as follows.


performs much better with this option in a large file system